### PR TITLE
Decouple exceptionMediator and schemaResolver

### DIFF
--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/DetailsValidationExceptionMediator.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/DetailsValidationExceptionMediator.java
@@ -1,0 +1,59 @@
+package com.github.novotnyr.springframework.web.jsonschema;
+
+import org.everit.json.schema.ValidationException;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.validation.Errors;
+
+/**
+ * Converts {@link ValidationException} from Everit JSON Schema
+ * to Spring {@link Errors} object.
+ * <p>
+ *     Since the {@link Errors} instance might already
+ *     contain some errors, we cannot use the {@link Converter} API.
+ *     Instead, we will contribute errors to the instance
+ *     provided in the second parameter.
+ * </p>
+ */
+public class DetailsValidationExceptionMediator implements ValidationExceptionMediator {
+    /**
+     * Does the best effort to convert the validation exception
+     * to errors that will be contributed to the {@link Errors} instance
+     * @param validationException Everit JSON schema validation errors
+     * @param errors binding errors that will be used in Spring MVC mechanism
+     */
+    public void convert(ValidationException validationException, Errors errors) {
+        if("exclusiveMinimum".equals(validationException.getKeyword())) {
+            String schemaLocation = validationException.getSchemaLocation();
+            String field = schemaLocation.substring(schemaLocation.lastIndexOf("/") + 1);
+            errors.rejectValue(field, "exclusive-minimum", validationException.getErrorMessage());
+        }
+        if("required".equals(validationException.getKeyword())) {
+            String schemaLocation = validationException.getSchemaLocation();
+            parseRequired(validationException, errors);
+        }
+        for (ValidationException nestedException : validationException.getCausingExceptions()) {
+            if(isRequired(nestedException)) {
+                parseRequired(nestedException, errors);
+                continue;
+            }
+            errors.reject("reject", validationException.getErrorMessage());
+        }
+    }
+
+    private boolean isRequired(ValidationException exception) {
+        return exception.getErrorMessage().startsWith("required key");
+    }
+
+    private void parseRequired(ValidationException exception, Errors errors) {
+        String message = exception.getMessage();
+        int leftBracket = message.indexOf("[");
+        int rightBracket = message.indexOf("]");
+        String field = message.substring(leftBracket + 1, rightBracket);
+        String schemaLocation = exception.getSchemaLocation();
+        if (schemaLocation.contains("/")) {
+            String path = schemaLocation.substring(schemaLocation.lastIndexOf("/") + 1);
+            errors.setNestedPath(path);
+        }
+        errors.rejectValue(field, "required-field", "Field is required");
+    }
+}

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolver.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolver.java
@@ -8,7 +8,6 @@ import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 import org.springframework.validation.AbstractBindingResult;
@@ -43,6 +42,11 @@ public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentRes
     private ValidationExceptionMediator validationExceptionMediator = new ValidationExceptionMediator();
 
     /**
+     * Component in charge of resolve schemas
+     */
+    private JsonSchemaResolver jsonSchemaResolver;
+
+    /**
      * Empty constructor.
      */
     public JsonRequestBodyArgumentResolver() {
@@ -51,10 +55,23 @@ public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentRes
 
     /**
      * Construct this argument resolver, with the corresponding delegate for reading
-     * payload values as if they were annotated with @{@link RequestBody}.
+     * payload values as if they were annotated with @{@link RequestBody}. Uses the default json schema resolver.
      */
     public JsonRequestBodyArgumentResolver(RequestResponseBodyMethodProcessor requestResponseBodyMethodProcessor) {
         this.requestResponseBodyMethodProcessor = requestResponseBodyMethodProcessor;
+        this.jsonSchemaResolver = new ParamNameJsonSchemaResolver();
+    }
+
+
+    /**
+     * Construct this argument resolver, with the corresponding delegate for reading
+     * payload values as if they were annotated with @{@link RequestBody}. Passing the json schema resolver
+     * as argument.
+     */
+    public JsonRequestBodyArgumentResolver(RequestResponseBodyMethodProcessor requestResponseBodyMethodProcessor,
+                                           JsonSchemaResolver jsonSchemaResolver) {
+        this.requestResponseBodyMethodProcessor = requestResponseBodyMethodProcessor;
+        this.jsonSchemaResolver = jsonSchemaResolver;
     }
 
     @Override
@@ -99,7 +116,7 @@ public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentRes
         int beforeSchemaValidationErrorCount = bindingResult.getErrorCount();
         String requestBodyJson = getJsonPayload(webRequest);
 
-        Resource jsonSchemaResource = resolveJsonSchemaResource(parameter);
+        Resource jsonSchemaResource = jsonSchemaResolver.resolveJsonSchemaResource(parameter, webRequest);
         validateRequestBody(requestBodyJson, jsonSchemaResource, bindingResult);
 
         if (bindingResult.getErrorCount() > beforeSchemaValidationErrorCount && throwExceptionOnSchemaValidationError) {
@@ -107,17 +124,7 @@ public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentRes
         }
     }
 
-    private Resource resolveJsonSchemaResource(MethodParameter methodParameter) {
-        JsonRequestBody annotation = methodParameter.getParameterAnnotation(JsonRequestBody.class);
-        String schemaPath = annotation.schemaPath();
-        if (! schemaPath.isEmpty()) {
-            return new ClassPathResource("/" + schemaPath + ".json");
-        } else {
-            String declaringClassName = methodParameter.getDeclaringClass().getSimpleName().toLowerCase();
-            String methodName = methodParameter.getMethod().getName();
-            return new ClassPathResource("/" + declaringClassName + "#" + methodName + ".json");
-        }
-    }
+
 
     private void validateRequestBody(String json, Resource jsonSchemaResource, BindingResult bindingResult) throws JsonSchemaException {
         try {

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolver.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolver.java
@@ -39,7 +39,7 @@ import java.nio.charset.StandardCharsets;
 public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentResolver {
     private RequestResponseBodyMethodProcessor requestResponseBodyMethodProcessor;
 
-    private ValidationExceptionMediator validationExceptionMediator = new ValidationExceptionMediator();
+    private ValidationExceptionMediator validationExceptionMediator = new DetailsValidationExceptionMediator();
 
     /**
      * Component in charge of resolve schemas
@@ -72,6 +72,19 @@ public class JsonRequestBodyArgumentResolver implements HandlerMethodArgumentRes
                                            JsonSchemaResolver jsonSchemaResolver) {
         this.requestResponseBodyMethodProcessor = requestResponseBodyMethodProcessor;
         this.jsonSchemaResolver = jsonSchemaResolver;
+    }
+
+    /**
+     * Construct this argument resolver, with the corresponding delegate for reading
+     * payload values as if they were annotated with @{@link RequestBody}. Passing the json schema resolver
+     * as argument and mediator.
+     */
+    public JsonRequestBodyArgumentResolver(RequestResponseBodyMethodProcessor argumentResolver,
+                                           JsonSchemaResolver jsonSchemaResolver,
+                                           ValidationExceptionMediator validationExceptionMediator) {
+        this(argumentResolver, jsonSchemaResolver);
+        this.validationExceptionMediator = validationExceptionMediator;
+
     }
 
     @Override

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor.java
@@ -27,6 +27,22 @@ import java.util.List;
  */
 public class JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor implements BeanPostProcessor {
 
+    private JsonSchemaResolver jsonSchemaResolver;
+
+    /**
+     * Creates a new post processor with the default {@link ParamNameJsonSchemaResolver}
+     */
+    public JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor() {
+        this.jsonSchemaResolver = new ParamNameJsonSchemaResolver();
+    }
+
+    /**
+     * Creates a new post processor with the schema resolver passed as argument
+     */
+    public JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor(JsonSchemaResolver jsonSchemaResolver) {
+        this.jsonSchemaResolver = jsonSchemaResolver;
+    }
+
     /**
      * Registers the JSON validating argument after {@link HandlerMethodArgumentResolver}.
      * @return the same bean, unchanged, unless it is {@link RequestMappingHandlerAdapter}.
@@ -40,7 +56,8 @@ public class JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor impleme
             for (int i = 0; i < argumentResolvers.size(); i++) {
                 HandlerMethodArgumentResolver argumentResolver = argumentResolvers.get(i);
                 if (argumentResolver instanceof RequestResponseBodyMethodProcessor) {
-                    JsonRequestBodyArgumentResolver jsonRequestBodyArgumentResolver = new JsonRequestBodyArgumentResolver((RequestResponseBodyMethodProcessor) argumentResolver);
+                    JsonRequestBodyArgumentResolver jsonRequestBodyArgumentResolver
+                            = new JsonRequestBodyArgumentResolver((RequestResponseBodyMethodProcessor) argumentResolver, jsonSchemaResolver);
                     extendedArgumentResolverList.add(i + 1, jsonRequestBodyArgumentResolver);
                     break;
                 }

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor.java
@@ -29,18 +29,25 @@ public class JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor impleme
 
     private JsonSchemaResolver jsonSchemaResolver;
 
+    private ValidationExceptionMediator validationExceptionMediator;
+
+
     /**
      * Creates a new post processor with the default {@link ParamNameJsonSchemaResolver}
      */
     public JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor() {
         this.jsonSchemaResolver = new ParamNameJsonSchemaResolver();
+        this.validationExceptionMediator = new DetailsValidationExceptionMediator();
+
     }
 
     /**
-     * Creates a new post processor with the schema resolver passed as argument
+     * Creates a new post processor with the schema resolver and exception mediator passed as arguments
      */
-    public JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor(JsonSchemaResolver jsonSchemaResolver) {
+    public JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor(JsonSchemaResolver jsonSchemaResolver,
+                                                       ValidationExceptionMediator validationExceptionMediator) {
         this.jsonSchemaResolver = jsonSchemaResolver;
+        this.validationExceptionMediator = validationExceptionMediator;
     }
 
     /**
@@ -57,7 +64,9 @@ public class JsonRequestBodyArgumentResolverRegisteringBeanPostProcessor impleme
                 HandlerMethodArgumentResolver argumentResolver = argumentResolvers.get(i);
                 if (argumentResolver instanceof RequestResponseBodyMethodProcessor) {
                     JsonRequestBodyArgumentResolver jsonRequestBodyArgumentResolver
-                            = new JsonRequestBodyArgumentResolver((RequestResponseBodyMethodProcessor) argumentResolver, jsonSchemaResolver);
+                            = new JsonRequestBodyArgumentResolver(
+                                    (RequestResponseBodyMethodProcessor) argumentResolver,
+                                    jsonSchemaResolver, validationExceptionMediator);
                     extendedArgumentResolverList.add(i + 1, jsonRequestBodyArgumentResolver);
                     break;
                 }

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonSchemaResolver.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonSchemaResolver.java
@@ -10,7 +10,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 public interface JsonSchemaResolver {
 
     /**
-     * Resolves json schemas according to method parameter and webrequest.
+     * Resolves json schemas according to method parameter and webrequest. Must always return a resource, if
+     * it is unavailable you can send a not found Resource
      */
     Resource resolveJsonSchemaResource(MethodParameter methodParameter, NativeWebRequest webRequest);
 }

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonSchemaResolver.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/JsonSchemaResolver.java
@@ -1,0 +1,16 @@
+package com.github.novotnyr.springframework.web.jsonschema;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.core.io.Resource;
+import org.springframework.web.context.request.NativeWebRequest;
+
+/**
+ * Interface to resolve json schemas according to method parameter and webrequest.
+ */
+public interface JsonSchemaResolver {
+
+    /**
+     * Resolves json schemas according to method parameter and webrequest.
+     */
+    Resource resolveJsonSchemaResource(MethodParameter methodParameter, NativeWebRequest webRequest);
+}

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ParamNameJsonSchemaResolver.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ParamNameJsonSchemaResolver.java
@@ -1,0 +1,25 @@
+package com.github.novotnyr.springframework.web.jsonschema;
+
+import com.github.novotnyr.springframework.web.jsonschema.annotation.JsonRequestBody;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.web.context.request.NativeWebRequest;
+
+/**
+ * Json schema resolver that resolves based on controller method name
+ */
+public class ParamNameJsonSchemaResolver implements JsonSchemaResolver {
+    public Resource resolveJsonSchemaResource(MethodParameter methodParameter, NativeWebRequest webRequest) {
+        JsonRequestBody annotation = methodParameter.getParameterAnnotation(JsonRequestBody.class);
+        String schemaPath = annotation.schemaPath();
+        if (! schemaPath.isEmpty()) {
+            return new ClassPathResource("/" + schemaPath + ".json");
+        } else {
+            String declaringClassName = methodParameter.getDeclaringClass().getSimpleName().toLowerCase();
+            String methodName = methodParameter.getMethod().getName();
+            return new ClassPathResource("/" + declaringClassName + "#" + methodName + ".json");
+        }
+    }
+}
+

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ValidationExceptionMediator.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ValidationExceptionMediator.java
@@ -49,7 +49,11 @@ public class ValidationExceptionMediator {
         int leftBracket = message.indexOf("[");
         int rightBracket = message.indexOf("]");
         String field = message.substring(leftBracket + 1, rightBracket);
-
+        String schemaLocation = exception.getSchemaLocation();
+        if (schemaLocation.contains("/")) {
+            String path = schemaLocation.substring(schemaLocation.lastIndexOf("/") + 1);
+            errors.setNestedPath(path);
+        }
         errors.rejectValue(field, "required-field", "Field is required");
     }
 }

--- a/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ValidationExceptionMediator.java
+++ b/src/main/java/com/github/novotnyr/springframework/web/jsonschema/ValidationExceptionMediator.java
@@ -1,59 +1,16 @@
 package com.github.novotnyr.springframework.web.jsonschema;
 
 import org.everit.json.schema.ValidationException;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.validation.Errors;
 
-/**
- * Converts {@link ValidationException} from Everit JSON Schema
- * to Spring {@link Errors} object.
- * <p>
- *     Since the {@link Errors} instance might already
- *     contain some errors, we cannot use the {@link Converter} API.
- *     Instead, we will contribute errors to the instance
- *     provided in the second parameter.
- * </p>
- */
-public class ValidationExceptionMediator {
+public interface ValidationExceptionMediator {
+
     /**
      * Does the best effort to convert the validation exception
      * to errors that will be contributed to the {@link Errors} instance
+     *
      * @param validationException Everit JSON schema validation errors
-     * @param errors binding errors that will be used in Spring MVC mechanism
+     * @param errors              binding errors that will be used in Spring MVC mechanism
      */
-    public void convert(ValidationException validationException, Errors errors) {
-        if("exclusiveMinimum".equals(validationException.getKeyword())) {
-            String schemaLocation = validationException.getSchemaLocation();
-            String field = schemaLocation.substring(schemaLocation.lastIndexOf("/") + 1);
-            errors.rejectValue(field, "exclusive-minimum", validationException.getErrorMessage());
-        }
-        if("required".equals(validationException.getKeyword())) {
-            String schemaLocation = validationException.getSchemaLocation();
-            parseRequired(validationException, errors);
-        }
-        for (ValidationException nestedException : validationException.getCausingExceptions()) {
-            if(isRequired(nestedException)) {
-                parseRequired(nestedException, errors);
-                continue;
-            }
-            errors.reject("reject", validationException.getErrorMessage());
-        }
-    }
-
-    private boolean isRequired(ValidationException exception) {
-        return exception.getErrorMessage().startsWith("required key");
-    }
-
-    private void parseRequired(ValidationException exception, Errors errors) {
-        String message = exception.getMessage();
-        int leftBracket = message.indexOf("[");
-        int rightBracket = message.indexOf("]");
-        String field = message.substring(leftBracket + 1, rightBracket);
-        String schemaLocation = exception.getSchemaLocation();
-        if (schemaLocation.contains("/")) {
-            String path = schemaLocation.substring(schemaLocation.lastIndexOf("/") + 1);
-            errors.setNestedPath(path);
-        }
-        errors.rejectValue(field, "required-field", "Field is required");
-    }
+    void convert(ValidationException validationException, Errors errors);
 }

--- a/src/test/java/com/github/novotnyr/springframework/BoxControllerTest.java
+++ b/src/test/java/com/github/novotnyr/springframework/BoxControllerTest.java
@@ -15,6 +15,10 @@ public class BoxControllerTest extends AbstractControllerTest {
     public void testPostOk() throws Exception {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("count", 1);
+        JSONObject inner = new JSONObject();
+        jsonObject.put("inner", inner);
+        inner.put("innerId", "1");
+        inner.put("innerName", "innerN");
 
         this.mvc.perform(
                 post("/boxes")
@@ -23,6 +27,26 @@ public class BoxControllerTest extends AbstractControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().is(200));
+    }
+
+    @Test
+    public void testPostInner() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("count", 1);
+        JSONObject inner = new JSONObject();
+        jsonObject.put("inner", inner);
+
+        this.mvc.perform(
+                post("/boxes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonObject.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(jsonPath("error.validation.field[0].code").value("required-field"))
+                .andExpect(jsonPath("error.validation.field[0].name").value("inner.innerId"))
+                .andExpect(jsonPath("error.validation.field[1].code").value("required-field"))
+                .andExpect(jsonPath("error.validation.field[1].name").value("inner.innerName"))
+                .andExpect(status().is(422));
     }
 
     @Test

--- a/src/test/java/com/github/novotnyr/springframework/BoxControllerTest.java
+++ b/src/test/java/com/github/novotnyr/springframework/BoxControllerTest.java
@@ -12,6 +12,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class BoxControllerTest extends AbstractControllerTest {
 
     @Test
+    public void testPostOk() throws Exception {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("count", 1);
+
+        this.mvc.perform(
+                post("/boxes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonObject.toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().is(200));
+    }
+
+    @Test
     public void testPost() throws Exception {
         JSONObject jsonObject = new JSONObject();
 

--- a/src/test/java/com/github/novotnyr/springframework/BoxRequest.java
+++ b/src/test/java/com/github/novotnyr/springframework/BoxRequest.java
@@ -32,4 +32,11 @@ public class BoxRequest {
     public UUID getId() {
         return id;
     }
+
+    private InnerBox inner;
+
+    public InnerBox getInner() {
+        return inner;
+    }
+
 }

--- a/src/test/java/com/github/novotnyr/springframework/InnerBox.java
+++ b/src/test/java/com/github/novotnyr/springframework/InnerBox.java
@@ -1,0 +1,28 @@
+package com.github.novotnyr.springframework;
+
+public class InnerBox {
+
+    private String innerId;
+
+    private String innerName;
+
+    public InnerBox() {
+    }
+
+    public String getInnerId() {
+        return innerId;
+    }
+
+    public void setInnerId(String innerId) {
+        this.innerId = innerId;
+    }
+
+    public String getInnerName() {
+        return innerName;
+    }
+
+    public void setInnerName(String innerName) {
+        this.innerName = innerName;
+    }
+
+}

--- a/src/test/resources/boxcontroller#register.json
+++ b/src/test/resources/boxcontroller#register.json
@@ -4,8 +4,22 @@
   "type": "object",
   "properties": {
     "count" : {
-      "type" : "string"
+      "type" : "integer"
+    }, "inner" : {
+      "type": "object",
+      "properties": {
+        "innerId": {
+          "type": "string"
+        },
+        "innerName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "innerId",
+        "innerName"
+      ]
     }
   },
-  "required": ["count"]
+  "required": ["count", "inner"]
 }


### PR DESCRIPTION
Hi novotnyr,

This PR contains:

1. schemaResolver decoupling. This means that you can inject a different schema resolver to resolve schemas in a different way than resolving based on "controller.method" (default resolver). In my case i want to go to an external service to get the schemas.

2. exceptionMediator decoupling. This means that you can inject a different component to map between schema validation errors and exceptions. In my case I cannot use the per-field rejection because I have some 'Object' typed fields. On these objects, the default mediator fails on field.reject because the field does not exists in 'Object' type.

3. Add support, in the default mediator, to reject nested fields. I got an exception when the default mediator tries to reject "foo.bar" field (bar is a nested field of foo).

I tried to keep backward compatibility in the api, adding new constructors, I hope everything is fine. Waiting for your feedback ;-)

Thanks and regards.